### PR TITLE
Use pkg-config for ncurses cflags/libs

### DIFF
--- a/backend/curses/backend.mk
+++ b/backend/curses/backend.mk
@@ -1,7 +1,7 @@
 
 BACKEND_SOURCES += src/main.c
 
-INCLUDES = $(shell ncursesw5-config --cflags)
+INCLUDES = $(shell pkg-config --cflags ncursesw)
 
 include src/common.mk
 

--- a/backend/curses/options
+++ b/backend/curses/options
@@ -1,1 +1,1 @@
-libs="$(ncursesw5-config --libs | tr ' ' '\n' | grep -v -- -ldl)"
+libs="$(pkg-config --libs ncursesw | tr ' ' '\n' | grep -v -- -ldl)"


### PR DESCRIPTION
On some distros like Alpine Linux, ncurses5 doesn't exist as a development package, and because of that, compiling with ncurses6 would throw a unknown command.

This should allow this package to be compiled on newer ncurses version without relying on just ncurses5.